### PR TITLE
Rename differential types

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,6 +5,7 @@ version = "0.1.1"
 
 [deps]
 ChainRules = "082447d4-558c-5d27-93f4-14fc19e9eca2"
+ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
 IntervalArithmetic = "d1acc4aa-44c8-5952-acd4-ba5d80a2a253"
 IntervalContractors = "15111844-de3b-5229-b4ba-526f2f385dc9"
 OrderedCollections = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
@@ -13,6 +14,7 @@ Symbolics = "0c5d862f-8b57-4792-8d23-62f2024744c7"
 
 [compat]
 ChainRules = "0.7"
+ChainRulesCore = "0.9.44"
 IntervalArithmetic = "0.17"
 IntervalContractors = "0.4"
 OrderedCollections = "1.4"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ReversePropagation"
 uuid = "527681c1-8309-4d3f-8790-caf822a419ba"
 authors = ["David P. Sanders <dpsanders@gmail.com> and contributors"]
-version = "0.1.0"
+version = "0.1.1"
 
 [deps]
 ChainRules = "082447d4-558c-5d27-93f4-14fc19e9eca2"

--- a/src/chain_rules_interface.jl
+++ b/src/chain_rules_interface.jl
@@ -4,7 +4,7 @@
 # Base.complex(x::Num) = x
 # Base.float(x::Num) = x
 
-@scalar_rule(^(x::Num, n::Integer), (n==1 ? 1 : n==2 ? 2x : n*x^(n-1), Zero()))
+@scalar_rule(^(x::Num, n::Integer), (n==1 ? 1 : n==2 ? 2x : n*x^(n-1), ZeroTangent()))
 
 adj(f, z̄::Num, x::Num) = (rrule(f, x)[2](z̄))[2]
 adj(f, z̄, x) = adj(f, Num(z̄), Num(x))
@@ -33,14 +33,14 @@ function tangent(eq::Assignment)
     lhs_tangent = Num(tangent(lhs(eq)))
 
     return Assignment(lhs_tangent,
-                    frule( (Zero(), rhs_tangents...), 
+                    frule( (ZeroTangent(), rhs_tangents...), 
                     op(eq), vars...)[2]
     )
 end
 
 
 
-# julia> frule((Zero(), ẋ, ẏ), *, x, y)
+# julia> frule((ZeroTangent(), ẋ, ẏ), *, x, y)
 # (x * y, (ẋ * y) + (x * ẏ))
 
 # julia> dargs = Num.(dotify.(args(eq)))
@@ -50,6 +50,6 @@ end
 #  x
 #  y
 
-# julia> frule( (Zero(), dargs...), op(eq), a...)
+# julia> frule( (ZeroTangent(), dargs...), op(eq), a...)
 # (x * y, (ẋ * y) + (x * ẏ))
 


### PR DESCRIPTION
We deprecated the old names in ChainRulesCore: https://github.com/JuliaDiff/ChainRulesCore.jl/pull/353

But I suspect that the @reexport macro does not reexport the deprecated names, so since ReversePropagation only depends on ChainRules it breaks. We are thinking about whether we should change that (https://github.com/JuliaDiff/ChainRules.jl/issues/415)

Anyway, here's the fix