### PR TITLE
Update ChainRules to match ChainRulesCore

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -13,7 +13,7 @@ SymbolicUtils = "d1185830-fcd6-423d-90d6-eec64667417b"
 Symbolics = "0c5d862f-8b57-4792-8d23-62f2024744c7"
 
 [compat]
-ChainRules = "0.7"
+ChainRules = "0.7, 0.8"
 ChainRulesCore = "0.9.44, 0.10"
 IntervalArithmetic = "0.17, 0.18"
 IntervalContractors = "0.4"


### PR DESCRIPTION
ChainRules v0.8 needs ChainRulesCore v0.10.
But also this is blocked by https://github.com/JuliaMath/SpecialFunctions.jl/pull/319
which is a downstream dependency somewhere