### PR TITLE
update deps

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -15,11 +15,11 @@ Symbolics = "0c5d862f-8b57-4792-8d23-62f2024744c7"
 [compat]
 ChainRules = "0.7, 0.8, 1"
 ChainRulesCore = "0.9.44, 0.10, 1"
-IntervalArithmetic = "0.17, 0.18"
+IntervalArithmetic = "0.17, 0.18, 0.19, 0.20"
 IntervalContractors = "0.4"
 OrderedCollections = "1.4"
-SymbolicUtils = "0.8, 0.9, 0.10, 0.11, 0.12, 0.13"
-Symbolics = "0.1, 1"
+SymbolicUtils = "0.8, 0.9, 0.10, 0.11, 0.12, 0.13, 0.14, 0.15, 0.16, 0.17"
+Symbolics = "0.1, 1, 2, 3"
 julia = "1.5, 1.6, 1.7, 1.8"
 
 [extras]


### PR DESCRIPTION
With these updates the package compiles and `Symbolics#v3.2.3` is installed by default.

Running the tests gives the following error

```julia
     Testing Running tests...
┌ Warning: Variable{T}(name, idx...) is deprecated, use variable(name, idx...; T=T)
│   caller = Variable at variable.jl:506 [inlined]
└ @ Core ~/.julia/packages/Symbolics/fd3w9/src/variable.jl:506
┌ Warning: Variable{T}(name, idx...) is deprecated, use variable(name, idx...; T=T)
│   caller = Variable at variable.jl:506 [inlined]
└ @ Core ~/.julia/packages/Symbolics/fd3w9/src/variable.jl:506
┌ Warning: Variable{T}(name, idx...) is deprecated, use variable(name, idx...; T=T)
│   caller = Variable at variable.jl:506 [inlined]
└ @ Core ~/.julia/packages/Symbolics/fd3w9/src/variable.jl:506
┌ Warning: Variable{T}(name, idx...) is deprecated, use variable(name, idx...; T=T)
│   caller = Variable at variable.jl:506 [inlined]
└ @ Core ~/.julia/packages/Symbolics/fd3w9/src/variable.jl:506
forward_backward_contractor: Error During Test at /home/mforets/.julia/dev/ReversePropagation/test/icp.jl:5
  Got exception outside of a @test
  MethodError: rev(::typeof(+), ::Num, ::Num, ::Num) is ambiguous. Candidates:
    rev(a, b::Num, c::Num, d::Num) in ReversePropagation at /home/mforets/.julia/packages/Symbolics/fd3w9/src/register.jl:52
    rev(a, b::Real, c::Num, d::Num) in ReversePropagation at /home/mforets/.julia/packages/Symbolics/fd3w9/src/register.jl:52
    rev(a, b::Num, c::Real, d::Num) in ReversePropagation at /home/mforets/.julia/packages/Symbolics/fd3w9/src/register.jl:52
    rev(a, b::Real, c::Real, d::Num) in ReversePropagation at /home/mforets/.julia/packages/Symbolics/fd3w9/src/register.jl:52
    rev(a, b::Num, c::Num, d::Real) in ReversePropagation at /home/mforets/.julia/packages/Symbolics/fd3w9/src/register.jl:52
    rev(a, b::Real, c::Num, d::Real) in ReversePropagation at /home/mforets/.julia/packages/Symbolics/fd3w9/src/register.jl:52
    rev(a, b::Num, c::Real, d::Real) in ReversePropagation at /home/mforets/.julia/packages/Symbolics/fd3w9/src/register.jl:52
    rev(::typeof(+), z::Real, x::Real, y::Real) in ReversePropagation at /home/mforets/.julia/dev/ReversePropagation/src/reverse_icp.jl:62
  Possible fix, define
    rev(::typeof(+), ::Num, ::Num, ::Num)
  Stacktrace:
    [1] rev(eq::SymbolicUtils.Code.Assignment, params::Vector{Any})
      @ ReversePropagation ~/.julia/dev/ReversePropagation/src/reverse_icp.jl:33
    [2] _broadcast_getindex_evalf
      @ ./broadcast.jl:670 [inlined]
    [3] _broadcast_getindex
      @ ./broadcast.jl:643 [inlined]
    [4] getindex
      @ ./broadcast.jl:597 [inlined]
    [5] macro expansion
      @ ./broadcast.jl:1005 [inlined]
    [6] macro expansion
      @ ./simdloop.jl:77 [inlined]
    [7] copyto!
      @ ./broadcast.jl:1004 [inlined]
    [8] copyto!
      @ ./broadcast.jl:957 [inlined]
    [9] copy
      @ ./broadcast.jl:929 [inlined]
   [10] materialize
      @ ./broadcast.jl:904 [inlined]
   [11] forward_backward_code(ex::Num, vars::Vector{Num}, params::Vector{Any})
      @ ReversePropagation ~/.julia/dev/ReversePropagation/src/reverse_icp.jl:97
   [12] forward_backward_expr(ex::Num, vars::Vector{Num}, params::Vector{Any})
      @ ReversePropagation ~/.julia/dev/ReversePropagation/src/reverse_icp.jl:136
   [13] forward_backward_contractor(ex::Num, vars::Vector{Num}, params::Vector{Any}) (repeats 2 times)
      @ ReversePropagation ~/.julia/dev/ReversePropagation/src/reverse_icp.jl:152
   [14] macro expansion
      @ ~/.julia/dev/ReversePropagation/test/icp.jl:12 [inlined]
   [15] macro expansion
      @ /buildworker/worker/package_linux64/build/usr/share/julia/stdlib/v1.7/Test/src/Test.jl:1282 [inlined]
   [16] top-level scope
      @ ~/.julia/dev/ReversePropagation/test/icp.jl:7
   [17] include(fname::String)
      @ Base.MainInclude ./client.jl:451
   [18] macro expansion
      @ ~/.julia/dev/ReversePropagation/test/runtests.jl:8 [inlined]
   [19] macro expansion
      @ /buildworker/worker/package_linux64/build/usr/share/julia/stdlib/v1.7/Test/src/Test.jl:1282 [inlined]
   [20] top-level scope
      @ ~/.julia/dev/ReversePropagation/test/runtests.jl:7
   [21] include(fname::String)
      @ Base.MainInclude ./client.jl:451
   [22] top-level scope
      @ none:6
   [23] eval
      @ ./boot.jl:373 [inlined]
   [24] exec_options(opts::Base.JLOptions)
      @ Base ./client.jl:268
   [25] _start()
      @ Base ./client.jl:495
Test Summary:                 | Pass  Error  Total
ReversePropagation.jl         |    4      1      5
  gradient                    |    4             4
  forward_backward_contractor |           1      1
ERROR: LoadError: Some tests did not pass: 4 passed, 0 failed, 1 errored, 0 broken.
in expression starting at /home/mforets/.julia/dev/ReversePropagation/test/runtests.jl:5
ERROR: Package ReversePropagation errored during testing
```