### PR TITLE
Fix method overwriting with Symbolics 7

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ReversePropagation"
 uuid = "527681c1-8309-4d3f-8790-caf822a419ba"
 authors = ["David P. Sanders <dpsanders@gmail.com> and contributors"]
-version = "0.4.0"
+version = "0.4.1"
 
 [deps]
 ChainRules = "082447d4-558c-5d27-93f4-14fc19e9eca2"

--- a/src/reverse_icp.jl
+++ b/src/reverse_icp.jl
@@ -61,12 +61,19 @@ const binary_functions = Dict(
                     :^     => :power_rev,
                     );
 
-for (f, f_rev) in binary_functions
-    # @eval rev(::typeof($f), z::Real, x::Real, y::Real) = $f_rev(z, x, y) 
-    @eval rev(::typeof($f), z, x, y) = $f_rev(z, x, y) 
+# Create individually-named symbolic functions to avoid method overwriting
+# (@register_symbolic widens typeof(f) to a single symbolic type, so all
+# binary/unary rev methods would collide if registered under the same name)
+const _rev_binary_lookup = Dict{Function,Function}()
 
-    @eval @register_symbolic rev(a::typeof($f), z, x, y) false
+for (f, f_rev) in binary_functions
+    rev_sym = Symbol(:_rev_, f)
+    @eval $rev_sym(z, x, y) = $f_rev(z, x, y)
+    @eval @register_symbolic $rev_sym(z, x, y) false
+    _rev_binary_lookup[eval(f)] = eval(rev_sym)
 end
+
+rev(f_val, z, x, y) = _rev_binary_lookup[f_val](z, x, y)
 
 
 const unary_functions = [:sqrt, :abs,
@@ -78,12 +85,17 @@ const unary_functions = [:sqrt, :abs,
             :asinh, :acosh, :atanh,
             :inv, :sign, :max, :min];
 
+const _rev_unary_lookup = Dict{Function,Function}()
+
 for f in unary_functions
     f_rev = Symbol(f, :_rev)
-    @eval rev(::typeof($f), z::Real, x::Real) = $f_rev(z, x)
-    # @eval @register_symbolic rev(a::typeof($f), z::Real, x::Real) false
-    @eval @register_symbolic rev(a::typeof($f), z, x) false
+    rev_sym = Symbol(:_rev_, f)
+    @eval $rev_sym(z, x) = $f_rev(z, x)
+    @eval @register_symbolic $rev_sym(z, x) false
+    _rev_unary_lookup[eval(f)] = eval(rev_sym)
 end
+
+rev(f_val, z, x) = _rev_unary_lookup[f_val](z, x)
 
 
 "Generate code (as Symbolics.Assignment) for forward--backward (HC4Revise) contractor"


### PR DESCRIPTION
## Summary
- Fixes `@register_symbolic` method overwriting errors when loading with Symbolics 7
- In Symbolics 7, `@register_symbolic` widens `typeof(f)` to a single `BasicSymbolic{SymReal}` type, so registering `rev(a::typeof(f), ...)` for each operator (`+`, `-`, `*`, etc.) produces identical method signatures that overwrite each other
- Fix by creating individually-named reverse functions (e.g. `_rev_+`, `_rev_sin`) each registered separately, with `Dict{Function,Function}` lookup tables to dispatch from the operation to its named reverse function

## Test plan
- [x] Package precompiles without warnings or errors
- [x] All 9 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)