### PR TITLE
Drop x86 CI runs

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -23,10 +23,6 @@ jobs:
           - windows-latest
         arch:
           - x64
-          - x86
-        exclude:
-          - os: macOS-latest
-            arch: x86
     steps:
       - uses: actions/checkout@v6
       - uses: julia-actions/setup-julia@v2


### PR DESCRIPTION
There are build errors in SymbolicUtils for 32-bit systems (`InexactError: trunc(UInt32, 0x8b414291c2ad93c0)`). I suggest to simply drop the tests for 32-bit systems.
Alternatively, someone should report that error upstream.