### PR TITLE
Add SSAFunction type, refactor pipeline to accept SSA input

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,0 +1,28 @@
+# ReversePropagation.jl release notes
+
+## v0.5.0
+
+### Breaking
+
+- `cse_equations`, `forward_backward_code`, and `gradient_code` now return an
+  `SSAFunction` instead of a `(code, final, …)` tuple. Callers that previously
+  destructured the tuple should instead access `.code`, `.output`, and
+  `.variables` (a `NamedTuple` carrying extras such as `constraint` or
+  `gradient`).
+
+### Added
+
+- New exported `SSAFunction` type representing a symbolic function in SSA
+  (single static assignment) form: a vector of `Assignment`s plus an output
+  variable and a `NamedTuple` of additional named variables.
+- `forward_backward_code`, `forward_backward_expr`, `forward_backward_contractor`,
+  and `gradient_code` each gain an `SSAFunction`-accepting method, so a
+  pre-computed SSA (e.g. the output of `gradient_code`) can be fed directly
+  into `forward_backward_contractor`. The expression-accepting methods become
+  thin wrappers that call `cse_equations` first.
+- `show` method for `SSAFunction` that pretty-prints the assignments, and
+  displays reverse operations as `rev(+)(…)` rather than raw generated names.
+
+### Fixed
+
+- Stale `istree` import (renamed to `iscall` in newer SymbolicUtils).

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ReversePropagation"
 uuid = "527681c1-8309-4d3f-8790-caf822a419ba"
 authors = ["David P. Sanders <dpsanders@gmail.com> and contributors"]
-version = "0.4.2"
+version = "0.5.0"
 
 [deps]
 ChainRules = "082447d4-558c-5d27-93f4-14fc19e9eca2"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ReversePropagation"
 uuid = "527681c1-8309-4d3f-8790-caf822a419ba"
 authors = ["David P. Sanders <dpsanders@gmail.com> and contributors"]
-version = "0.4.1"
+version = "0.4.2"
 
 [deps]
 ChainRules = "082447d4-558c-5d27-93f4-14fc19e9eca2"

--- a/src/ReversePropagation.jl
+++ b/src/ReversePropagation.jl
@@ -1,6 +1,6 @@
 module ReversePropagation
 
-export gradient, forward_backward_contractor
+export gradient, forward_backward_contractor, SSAFunction
 
 import Symbolics: toexpr, variable
 
@@ -10,7 +10,7 @@ using SymbolicUtils.Rewriters
 
 using Symbolics
 using Symbolics: value,
-                istree, operation, arguments,
+                iscall, operation, arguments,
                 Assignment
 
 using IntervalContractors
@@ -36,6 +36,7 @@ using ChainRulesCore, ChainRules
 # Base.show(io::IO, eq::Assignment) = print(io, lhs(eq), " := ", rhs(eq))
 
 include("make_variable.jl")
+include("ssa.jl")
 include("chain_rules_interface.jl")
 include("cse.jl")
 include("reverse_diff.jl")

--- a/src/cse.jl
+++ b/src/cse.jl
@@ -58,11 +58,12 @@ function cse(ex)
     return dict, final 
 end
 
-"Version of CSE returning a vector of equations"
-function cse_equations(ex) 
-    dict, final = cse(ex) 
+"CSE returning an SSAFunction"
+function cse_equations(ex)
+    dict, final = cse(ex)
 
-    return [Assignment(rhs, lhs) for (lhs, rhs) in pairs(dict)], final
+    code = [Assignment(rhs, lhs) for (lhs, rhs) in pairs(dict)]
+    return SSAFunction(code, final)
 end
 
 

--- a/src/reverse_diff.jl
+++ b/src/reverse_diff.jl
@@ -206,7 +206,7 @@ function gradient_code(ssa::SSAFunction, vars)
 
     code = [forward_code; initialization_code; reverse_code]
 
-    return SSAFunction(code, final), gradient_vars
+    return SSAFunction(code, final, (; gradient=gradient_vars))
 end
 
 
@@ -218,11 +218,11 @@ make_tuple(s::Symbol) = make_tuple([s])
 # toexpr(ex::Assignment) = toexpr(Equation(ex.lhs, ex.rhs))
 
 function gradient_expr(ex, vars)
-    result_ssa, gradient_vars = gradient_code(ex, vars)
+    result_ssa = gradient_code(ex, vars)
 
     code = Expr(:block, toexpr.(result_ssa.code)...)
 
-    return code, result_ssa.output, gradient_vars
+    return code, result_ssa.output, result_ssa.variables.gradient
 end
 
 

--- a/src/reverse_diff.jl
+++ b/src/reverse_diff.jl
@@ -206,7 +206,7 @@ function gradient_code(ssa::SSAFunction, vars)
 
     code = [forward_code; initialization_code; reverse_code]
 
-    return code, final, gradient_vars
+    return SSAFunction(code, final), gradient_vars
 end
 
 
@@ -218,11 +218,11 @@ make_tuple(s::Symbol) = make_tuple([s])
 # toexpr(ex::Assignment) = toexpr(Equation(ex.lhs, ex.rhs))
 
 function gradient_expr(ex, vars)
-    symbolic_code, final, gradient_vars = gradient_code(ex, vars)
+    result_ssa, gradient_vars = gradient_code(ex, vars)
 
-    code = Expr(:block, toexpr.(symbolic_code)...)
+    code = Expr(:block, toexpr.(result_ssa.code)...)
 
-    return code, final, gradient_vars
+    return code, result_ssa.output, gradient_vars
 end
 
 

--- a/src/reverse_diff.jl
+++ b/src/reverse_diff.jl
@@ -189,13 +189,17 @@ Return code for forward and reverse pass, as a vector of Assignments.
 `gradient_vars` are the output variables from the reverse pass.
 """
 function gradient_code(ex, vars)
+    ssa = cse_equations(ex)
+    return gradient_code(ssa, vars)
+end
 
-    forward_code, final = cse_equations(ex)
-    # reverse_code, gradient_vars = reverse_pass(vars, forward_code, final)
+function gradient_code(ssa::SSAFunction, vars)
+    forward_code = ssa.code
+    final = ssa.output
 
     reverse_code, gradient_vars, assigned = simple_reverse_pass(vars, forward_code)
 
-    initialization_code = [Assignment(bar(final), 1)]  # need typed 1 and 0?
+    initialization_code = [Assignment(bar(final), 1)]
 
     unassigned = setdiff(gradient_vars, assigned)
     append!(initialization_code, [Assignment(var, 0) for var in unassigned])

--- a/src/reverse_icp.jl
+++ b/src/reverse_icp.jl
@@ -120,7 +120,7 @@ function forward_backward_code(ssa::SSAFunction, vars, params=[])
 
     code = [forward_code; constraint_code; reverse_code]
 
-    return code, final_var, constraint_var
+    return SSAFunction(code, final_var), constraint_var
 end
 
 # code, final, constraint = forward_backward_code(x^2 + a*y^2, [x, y], [a])
@@ -159,12 +159,12 @@ end
 
 "Build Julia code for forward_backward contractor from an SSAFunction"
 function forward_backward_expr(ssa::SSAFunction, vars, params=[])
-    symbolic_code, final_var, constraint_var = forward_backward_code(ssa, vars, params)
+    result_ssa, constraint_var = forward_backward_code(ssa, vars, params)
 
-    code = toexpr.(symbolic_code)
+    code = toexpr.(result_ssa.code)
     all_code = Expr(:block, code...)
 
-    return all_code, final_var, constraint_var
+    return all_code, result_ssa.output, constraint_var
 end
 
 

--- a/src/reverse_icp.jl
+++ b/src/reverse_icp.jl
@@ -98,24 +98,25 @@ end
 rev(f_val, z, x) = _rev_unary_lookup[f_val](z, x)
 
 
-"Generate code (as Symbolics.Assignment) for forward--backward (HC4Revise) contractor"
+"Generate code (as Symbolics.Assignment) for forward--backward (HC4Revise) contractor from a symbolic expression"
 function forward_backward_code(ex, vars, params=[])
+    ssa = cse_equations(ex)
+    return forward_backward_code(ssa, vars, params)
+end
+
+"Generate forward--backward contractor code from an SSAFunction"
+function forward_backward_code(ssa::SSAFunction, vars, params=[])
 
     final_var = make_variable(:value)  # to record the output of running the forward interval function
     constraint_var = make_variable(:constraint)   # symbolic constraint variable
 
-    forward_code, last = cse_equations(ex)
-
-    # @show forward_code
-
-
-    # @show constraint_var, final_var
+    forward_code = ssa.code
+    last = ssa.output
 
     constraint_code = [Assignment(final_var, last),
                         Assignment(last, last ⊓ constraint_var)]
 
     reverse_code = rev.(reverse(forward_code), Ref(params))
-
 
     code = [forward_code; constraint_code; reverse_code]
 
@@ -150,12 +151,15 @@ Symbolics.toexpr(t::Tuple) = Symbolics.toexpr(Symbolics.MakeTuple(t))
 #     return code, final, return_tuple
 # end
 
-"Build Julia code for forward_backward contractor"
+"Build Julia code for forward_backward contractor from a symbolic expression"
 function forward_backward_expr(ex, vars, params=[])
+    ssa = cse_equations(ex)
+    return forward_backward_expr(ssa, vars, params)
+end
 
-    symbolic_code, final_var, constraint_var = forward_backward_code(ex, vars, params)
-
-    # @show symbolic_code
+"Build Julia code for forward_backward contractor from an SSAFunction"
+function forward_backward_expr(ssa::SSAFunction, vars, params=[])
+    symbolic_code, final_var, constraint_var = forward_backward_code(ssa, vars, params)
 
     code = toexpr.(symbolic_code)
     all_code = Expr(:block, code...)
@@ -164,16 +168,11 @@ function forward_backward_expr(ex, vars, params=[])
 end
 
 
-# forward_backward_expr(ex, vars, [a])
-
-
-function forward_backward_contractor(ex, vars, params=[])
-
-    code, final_var, constraint_var = forward_backward_expr(ex, vars, params)
+function forward_backward_contractor(ssa::SSAFunction, vars, params=[])
+    code, final_var, constraint_var = forward_backward_expr(ssa, vars, params)
 
     input_vars = toexpr(Symbolics.MakeTuple(vars))
     final = toexpr(final_var)
-
     constraint = toexpr(constraint_var)
 
     if !isempty(params)
@@ -186,9 +185,7 @@ function forward_backward_contractor(ex, vars, params=[])
                     return $input_vars, $(final)
                 end
             end
-
     else
-
         function_code =
             quote
                 ($input_vars, $constraint) -> begin
@@ -196,12 +193,14 @@ function forward_backward_contractor(ex, vars, params=[])
                     return $input_vars, $(final)
                 end
             end
-
     end
 
     return eval(function_code)
+end
 
-
+function forward_backward_contractor(ex, vars, params=[])
+    ssa = cse_equations(ex)
+    return forward_backward_contractor(ssa, vars, params)
 end
 
 # ex = x^2 + a * y^2

--- a/src/reverse_icp.jl
+++ b/src/reverse_icp.jl
@@ -120,7 +120,7 @@ function forward_backward_code(ssa::SSAFunction, vars, params=[])
 
     code = [forward_code; constraint_code; reverse_code]
 
-    return SSAFunction(code, final_var), constraint_var
+    return SSAFunction(code, final_var, (; constraint=constraint_var))
 end
 
 # code, final, constraint = forward_backward_code(x^2 + a*y^2, [x, y], [a])
@@ -159,12 +159,12 @@ end
 
 "Build Julia code for forward_backward contractor from an SSAFunction"
 function forward_backward_expr(ssa::SSAFunction, vars, params=[])
-    result_ssa, constraint_var = forward_backward_code(ssa, vars, params)
+    result_ssa = forward_backward_code(ssa, vars, params)
 
     code = toexpr.(result_ssa.code)
     all_code = Expr(:block, code...)
 
-    return all_code, result_ssa.output, constraint_var
+    return all_code, result_ssa.output, result_ssa.variables.constraint
 end
 
 

--- a/src/ssa.jl
+++ b/src/ssa.jl
@@ -19,3 +19,12 @@ function Base.show(io::IO, ssa::SSAFunction)
     n = length(ssa.code)
     print(io, "SSAFunction($n assignments, output = $(ssa.output))")
 end
+
+function Base.show(io::IO, ::MIME"text/plain", ssa::SSAFunction)
+    n = length(ssa.code)
+    println(io, "SSAFunction with $n assignments:")
+    for eq in ssa.code
+        println(io, "  $(eq.lhs) := $(eq.rhs)")
+    end
+    print(io, "Output: $(ssa.output)")
+end

--- a/src/ssa.jl
+++ b/src/ssa.jl
@@ -6,6 +6,7 @@ A symbolic function in SSA (single static assignment) form.
 Fields:
 - `code`: vector of `Assignment`s, each of the form `_a := f(x, y)`
 - `output`: the symbolic variable holding the final result
+- `variables`: a `NamedTuple` of extra named variables (e.g. `constraint`, `gradient`)
 
 An `SSAFunction` is produced by `cse_equations` (common subexpression elimination)
 and can be passed to `forward_backward_code` or `gradient_code` as input.
@@ -13,18 +14,43 @@ and can be passed to `forward_backward_code` or `gradient_code` as input.
 struct SSAFunction
     code::Vector{Assignment}
     output
+    variables::NamedTuple
 end
+
+SSAFunction(code, output) = SSAFunction(code, output, (;))
 
 function Base.show(io::IO, ssa::SSAFunction)
     n = length(ssa.code)
     print(io, "SSAFunction($n assignments, output = $(ssa.output))")
 end
 
+_show_lhs(x) = string(x)
+_show_lhs(t::Symbolics.MakeTuple) = "(" * join(t.elems, ", ") * ")"
+
+function _show_rhs(rhs)
+    val = Symbolics.value(rhs)
+    if SymbolicUtils.iscall(val)
+        f = SymbolicUtils.operation(val)
+        name = string(nameof(f))
+        if startswith(name, "_rev_")
+            op = name[6:end]
+            args = join(SymbolicUtils.arguments(val), ", ")
+            return "rev($op)($args)"
+        end
+    end
+    return string(rhs)
+end
+
 function Base.show(io::IO, ::MIME"text/plain", ssa::SSAFunction)
     n = length(ssa.code)
     println(io, "SSAFunction with $n assignments:")
     for eq in ssa.code
-        println(io, "  $(eq.lhs) := $(eq.rhs)")
+        println(io, "  $(_show_lhs(eq.lhs)) := $(_show_rhs(eq.rhs))")
     end
     print(io, "Output: $(ssa.output)")
+    if !isempty(keys(ssa.variables))
+        for (k, v) in pairs(ssa.variables)
+            print(io, "\n", k, ": ", v)
+        end
+    end
 end

--- a/src/ssa.jl
+++ b/src/ssa.jl
@@ -1,0 +1,21 @@
+"""
+    SSAFunction
+
+A symbolic function in SSA (single static assignment) form.
+
+Fields:
+- `code`: vector of `Assignment`s, each of the form `_a := f(x, y)`
+- `output`: the symbolic variable holding the final result
+
+An `SSAFunction` is produced by `cse_equations` (common subexpression elimination)
+and can be passed to `forward_backward_code` or `gradient_code` as input.
+"""
+struct SSAFunction
+    code::Vector{Assignment}
+    output
+end
+
+function Base.show(io::IO, ssa::SSAFunction)
+    n = length(ssa.code)
+    print(io, "SSAFunction($n assignments, output = $(ssa.output))")
+end

--- a/test/icp.jl
+++ b/test/icp.jl
@@ -37,6 +37,21 @@ end
     @test eq(C(IntervalBox(-10..10, -10..10), 0..1, 1..1), ( (-1..1, -1..1), 0..200 ))
 end
 
+@testset "SSAFunction with forward_backward_contractor" begin
+
+    vars = @variables x, y
+
+    ex = x^2 + y^2
+
+    # Build SSAFunction manually via cse_equations, then pass to forward_backward_contractor
+    ssa = ReversePropagation.cse_equations(ex)
+    @test ssa isa SSAFunction
+    @test length(ssa.code) > 0
+
+    C = forward_backward_contractor(ssa, vars)
+    @test eq(C(IntervalBox(-10..10, -10..10), 0..1), ( (-1..1, -1..1), 0..200 ))
+end
+
 @testset "bare intervals" begin
 
     vars = @variables x, y


### PR DESCRIPTION
## Summary

- Introduces `SSAFunction` struct to represent decomposed expressions in SSA form (a vector of `Assignment`s + output variable)
- `cse_equations` now returns `SSAFunction` instead of a `(code, final)` tuple
- `forward_backward_code`, `forward_backward_expr`, and `forward_backward_contractor` each get an `SSAFunction`-accepting method; expression-accepting methods become thin wrappers
- `gradient_code` similarly accepts `SSAFunction`
- Fixes stale `istree` import → `iscall`

This enables passing pre-computed SSA (e.g. from `gradient_code`) into `forward_backward_contractor`, which is needed for derivative constraints (next PR).

## Test plan

- [x] All 12 ReversePropagation tests pass (was 9, +3 new for SSAFunction path)
- [x] All 16 IntervalConstraintProgramming tests pass (downstream consumer)

🤖 Generated with [Claude Code](https://claude.com/claude-code)