### PR TITLE
Forward-mode AD via the shared scalar rule table

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,20 @@
 # ReversePropagation.jl release notes
 
+## v0.7.0
+
+### Added
+
+- Forward-mode automatic differentiation via the same scalar rule table
+  used for reverse-mode. Two new entry points:
+  - `tangent_code(ssa_or_expr, vars)` — appends one tangent assignment
+    per forward assignment, surfacing `input_tangents` and
+    `output_tangent` in the returned `SSAFunction.variables`.
+  - `tangent(ex, vars)` — compiles a callable
+    `(__inputs, __tangents) -> (value, directional_derivative)`.
+- The directional derivative `t((x,y), (1,0))` matches the first
+  component of `gradient((x,y))`; `t((x,y), dir)` computes the full
+  Gateaux derivative along `dir`.
+
 ## v0.6.0
 
 ### Breaking

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ReversePropagation"
 uuid = "527681c1-8309-4d3f-8790-caf822a419ba"
 authors = ["David P. Sanders <dpsanders@gmail.com> and contributors"]
-version = "0.6.0"
+version = "0.7.0"
 
 [deps]
 IntervalArithmetic = "d1acc4aa-44c8-5952-acd4-ba5d80a2a253"

--- a/src/ReversePropagation.jl
+++ b/src/ReversePropagation.jl
@@ -1,6 +1,6 @@
 module ReversePropagation
 
-export gradient, forward_backward_contractor, SSAFunction, binarize_ssa
+export gradient, tangent, forward_backward_contractor, SSAFunction, binarize_ssa
 
 import Symbolics: toexpr, variable
 
@@ -41,6 +41,7 @@ include("ssa.jl")
 include("scalar_rules.jl")
 include("cse.jl")
 include("reverse_diff.jl")
+include("forward_diff.jl")
 include("reverse_icp.jl")
 
 end

--- a/src/forward_diff.jl
+++ b/src/forward_diff.jl
@@ -1,0 +1,98 @@
+"""
+Forward-mode automatic differentiation on top of `SSAFunction`.
+
+Given an SSA `_a := f(x₁, …, xₙ)`, the tangent (directional derivative)
+is ``_ȧ = Σᵢ (∂f/∂xᵢ) · ẋᵢ``. We reuse the scalar rule table from
+`scalar_rules.jl` — the same rules power both reverse- and forward-mode,
+so there is no second source of truth to keep in sync.
+"""
+
+
+"Symbolic tangent variable for `v` (overdot notation)."
+dotted(v::Num) = dotted(Symbolics.value(v))
+dotted(v::Real) = Num(0)
+function dotted(v::SymbolicUtils.BasicSymbolic)
+    return Num(Symbolics.variable(Symbol(string(v), '̇')))
+end
+
+
+"Tangent assignment for one forward assignment `eq`."
+function tangent_eq(eq::Assignment)
+    vs = args(eq)
+    lhs_dot = dotted(lhs(eq))
+    if length(vs) == 1
+        dfdx = unary_rule(op(eq), vs[1])
+        rhs = dfdx * dotted(vs[1])
+    elseif length(vs) == 2
+        x, y = vs
+        dfdx, dfdy = binary_rule(op(eq), x, y)
+        rhs = dfdx * dotted(x) + dfdy * dotted(y)
+    else
+        error("tangent_eq: unsupported arity $(length(vs))")
+    end
+    return Assignment(lhs_dot, rhs)
+end
+
+
+"""
+    tangent_code(ssa::SSAFunction, vars) -> SSAFunction
+    tangent_code(ex::Num, vars) -> SSAFunction
+
+Extend `ssa` (or `cse_equations(ex)`) with forward-mode tangent assignments.
+
+The returned `SSAFunction.code` contains the original forward assignments
+followed by one tangent assignment per forward assignment. The extra
+outputs are surfaced in `variables`:
+
+- `input_tangents`: the tangent inputs the caller must supply (one per `vars`).
+- `output_tangent`: the tangent of `ssa.output`.
+"""
+function tangent_code(ssa::SSAFunction, vars)
+    fwd = ssa.code
+    tang = [tangent_eq(eq) for eq in fwd]
+    combined = [fwd; tang]
+    extras = (
+        input_tangents = collect(dotted.(vars)),
+        output_tangent = dotted(ssa.output),
+    )
+    return SSAFunction(combined, ssa.output, merge(ssa.variables, extras))
+end
+
+tangent_code(ex::Num, vars) = tangent_code(cse_equations(ex), vars)
+
+
+"""
+    tangent(ex, vars) -> callable
+
+Build a compiled forward-mode function of the form
+`(__inputs, __tangents) -> (value, directional_derivative)`.
+
+The directional derivative is ``Σᵢ (∂f/∂xᵢ)(__inputs) · __tangents[i]`` —
+set `__tangents = (1, 0, …, 0)` for ``∂f/∂x₁``, and so on.
+"""
+function tangent(ex::Num, vars)
+    ssa = tangent_code(ex, vars)
+
+    code = Expr(:block, toexpr.(ssa.code)...)
+
+    input_vars         = toexpr(Symbolics.MakeTuple(vars))
+    input_tangent_vars = toexpr(Symbolics.MakeTuple(ssa.variables.input_tangents))
+    final              = toexpr(ssa.output)
+    final_tangent      = toexpr(ssa.variables.output_tangent)
+
+    # NB: the first arg is named `__inputs` (not `__args`); `__args` collides
+    # with RuntimeGeneratedFunctions' own internal binding and triggers a
+    # spurious `BoundsError` at call time.
+    full_code = :(
+        (__inputs, __tangents) -> begin
+            $input_vars         = __inputs
+            $input_tangent_vars = __tangents
+            $code
+            return ($final, $final_tangent)
+        end
+    )
+
+    return @RuntimeGeneratedFunction(full_code)
+end
+
+tangent(f, vars) = tangent(f(vars), vars)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,6 +7,7 @@ using Test
     include("gradient.jl")
     include("icp.jl")
     include("hardening.jl")
+    include("tangent.jl")
 
 end
 

--- a/test/tangent.jl
+++ b/test/tangent.jl
@@ -1,0 +1,52 @@
+@testset "forward-mode tangent" begin
+
+    vars = @variables x, y
+
+    @testset "directional derivative matches reverse-mode gradient" begin
+        # f = x² + y² at (3, 4): ∇f = (2x, 2y) = (6, 8)
+        f = x^2 + y^2
+        t = tangent(f, [x, y])
+        g = ReversePropagation.gradient(f, [x, y])
+
+        pt = (3.0, 4.0)
+        (v_fwd_x, dx) = t(pt, (1.0, 0.0))
+        (v_fwd_y, dy) = t(pt, (0.0, 1.0))
+        (v_rev, grad) = g(pt)
+
+        @test v_fwd_x == v_rev == 25.0
+        @test v_fwd_y == v_rev
+        @test (dx, dy) == grad
+    end
+
+    @testset "transcendental" begin
+        # d/dx sin(x*y) = y cos(x*y) ; d/dy sin(x*y) = x cos(x*y)
+        t = tangent(sin(x*y), [x, y])
+        pt = (1.0, 2.0)
+        (_, dx) = t(pt, (1.0, 0.0))
+        (_, dy) = t(pt, (0.0, 1.0))
+        @test dx ≈ 2.0 * cos(2.0)
+        @test dy ≈ 1.0 * cos(2.0)
+    end
+
+    @testset "arbitrary direction" begin
+        # Full Gateaux derivative: directional derivative along v equals ⟨∇f, v⟩
+        f = x^2 * y + y^3
+        t = tangent(f, [x, y])
+        g = ReversePropagation.gradient(f, [x, y])
+
+        pt = (2.0, 3.0)
+        dir = (0.7, -0.4)
+        (_, dfdv) = t(pt, dir)
+        (_, grad) = g(pt)
+        @test dfdv ≈ grad[1] * dir[1] + grad[2] * dir[2]
+    end
+
+    @testset "tangent_code surfaces input/output tangents" begin
+        ssa = ReversePropagation.tangent_code(x^2 + y^2, [x, y])
+        @test length(ssa.variables.input_tangents) == 2
+        @test ssa.variables.output_tangent isa Num
+        # Every original forward assignment produces exactly one tangent assignment.
+        fwd_ssa = ReversePropagation.cse_equations(x^2 + y^2)
+        @test length(ssa.code) == 2 * length(fwd_ssa.code)
+    end
+end


### PR DESCRIPTION
## Summary

Stacked on #83. Adds forward-mode AD, reusing the `unary_rule` / `binary_rule` dispatch table that PR #83 introduced for reverse-mode. One rule table, two AD passes — no second source of truth to drift.

## API

- `dotted(v)` — tangent variable for `v`, written with a combining overdot (parallel to the internal `bar(v)` for reverse mode).
- `tangent_code(ex_or_ssa, vars)` — appends one tangent assignment per forward assignment, surfacing `input_tangents` and `output_tangent` in `SSAFunction.variables`.
- `tangent(ex, vars)` — exported. Compiles a callable
  ```julia
  (__inputs, __tangents) -> (value, directional_derivative)
  ```

## Behaviour

```julia
@variables x y
t = tangent(x^2 + y^2, [x, y])
t((3.0, 4.0), (1.0, 0.0))   # (25.0, 6.0) — ∂f/∂x = 2x
t((3.0, 4.0), (0.0, 1.0))   # (25.0, 8.0) — ∂f/∂y = 2y
t((3.0, 4.0), (0.7, -0.4))  # full Gateaux derivative along (0.7, -0.4)
```

Verified against reverse-mode `gradient` in tests.

## Note on RGF naming

The compiled function's first argument is `__inputs`, not `__args`. The latter collides with `RuntimeGeneratedFunctions`' own internal binding and triggers a spurious `BoundsError` at call time. Documented inline where the Expr is built.

## Test plan

- [x] 68/68 tests pass (59 inherited from #83, +9 new for tangent).
- [x] Directional derivative matches reverse-mode gradient component-by-component.
- [x] Full Gateaux derivative along arbitrary direction matches `⟨∇f, v⟩`.

## Follow-ups

Hessian via forward-over-reverse (applying `tangent_code` to the SSA produced by `gradient_code`) will land in a separate PR on top of this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)