### PR TITLE
Hessian via forward-over-reverse

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,24 @@
 # ReversePropagation.jl release notes
 
+## v0.8.0
+
+### Added
+
+- `hessian(ex, vars)` — compiled function returning `(value, gradient,
+  Hessian)`. Built by forward-over-reverse: one reverse-mode pass for
+  the gradient SSA, a forward-mode (tangent) pass attached on top, and
+  evaluated at the `n` unit vectors at runtime to assemble the full
+  `n × n` Hessian matrix. Reuses the same scalar rule table as
+  `gradient` and `tangent`.
+
+### Fixed
+
+- `tangent_eq` now handles non-call assignments (bare-variable identity
+  copies and bare-constant seeds) that appear naturally in the output
+  of `gradient_code`. Previously it assumed every rhs was a function
+  call; that assumption held for `cse_equations(ex)` output but failed
+  as soon as a gradient SSA was used as an input to forward-mode AD.
+
 ## v0.7.0
 
 ### Added

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ReversePropagation"
 uuid = "527681c1-8309-4d3f-8790-caf822a419ba"
 authors = ["David P. Sanders <dpsanders@gmail.com> and contributors"]
-version = "0.7.0"
+version = "0.8.0"
 
 [deps]
 IntervalArithmetic = "d1acc4aa-44c8-5952-acd4-ba5d80a2a253"

--- a/src/ReversePropagation.jl
+++ b/src/ReversePropagation.jl
@@ -1,6 +1,6 @@
 module ReversePropagation
 
-export gradient, tangent, forward_backward_contractor, SSAFunction, binarize_ssa
+export gradient, tangent, hessian, forward_backward_contractor, SSAFunction, binarize_ssa
 
 import Symbolics: toexpr, variable
 
@@ -42,6 +42,7 @@ include("scalar_rules.jl")
 include("cse.jl")
 include("reverse_diff.jl")
 include("forward_diff.jl")
+include("hessian.jl")
 include("reverse_icp.jl")
 
 end

--- a/src/forward_diff.jl
+++ b/src/forward_diff.jl
@@ -18,18 +18,28 @@ end
 
 "Tangent assignment for one forward assignment `eq`."
 function tangent_eq(eq::Assignment)
-    vs = args(eq)
     lhs_dot = dotted(lhs(eq))
-    if length(vs) == 1
-        dfdx = unary_rule(op(eq), vs[1])
-        rhs = dfdx * dotted(vs[1])
-    elseif length(vs) == 2
-        x, y = vs
-        dfdx, dfdy = binary_rule(op(eq), x, y)
-        rhs = dfdx * dotted(x) + dfdy * dotted(y)
+    rhs_val = Symbolics.value(eq.rhs)
+
+    if SymbolicUtils.iscall(rhs_val)
+        vs = args(eq)
+        if length(vs) == 1
+            dfdx = unary_rule(op(eq), vs[1])
+            rhs = dfdx * dotted(vs[1])
+        elseif length(vs) == 2
+            x, y = vs
+            dfdx, dfdy = binary_rule(op(eq), x, y)
+            rhs = dfdx * dotted(x) + dfdy * dotted(y)
+        else
+            error("tangent_eq: unsupported arity $(length(vs))")
+        end
     else
-        error("tangent_eq: unsupported arity $(length(vs))")
+        # Non-call rhs: a bare variable is propagated through (`_ā := _c̄`
+        # becomes `_ā̇ := _c̄̇`); a bare constant has tangent 0. `dotted`
+        # handles both dispatches.
+        rhs = dotted(eq.rhs)
     end
+
     return Assignment(lhs_dot, rhs)
 end
 

--- a/src/hessian.jl
+++ b/src/hessian.jl
@@ -1,0 +1,83 @@
+"""
+Hessian computation via forward-over-reverse: build the gradient SSA
+(one reverse-mode pass), then attach a tangent (forward-mode) pass that
+propagates derivatives of every SSA variable — including the gradient
+components `variables.gradient`. Evaluating the tangent pass with the
+`i`-th unit vector as the input direction yields the `i`-th row of the
+Hessian.
+"""
+
+
+"""
+    hessian(ex, vars) -> callable
+
+Build a compiled function `__inputs -> (value, gradient, Hessian)` where
+`gradient` is an `n`-tuple and `Hessian` is an `n × n` matrix.
+
+Implementation: one compiled `(inputs, direction) -> (value, gradient,
+gradient_tangent)` built by forward-over-reverse, invoked `n` times at
+runtime with unit-vector directions. Cost is `n` forward/reverse passes
+for the Hessian build, which is acceptable for the small-`n` symbolic
+regime this package targets; denser cases can compile `n` tangent passes
+into a single SSA later.
+"""
+function hessian(ex::Num, vars)
+    n = length(vars)
+
+    grad_ssa = gradient_code(cse_equations(ex), vars)
+    g_syms   = grad_ssa.variables.gradient
+
+    # Binarize before tangenting: the adjoint pass can emit n-ary muls
+    # (e.g. `2 * _b̄ * x`) that `tangent_eq` doesn't handle. `binarize_ssa`
+    # preserves `.variables` (so `g_syms` still point into the code), it
+    # just rewrites compound rhs's into elementary binary/unary form.
+    grad_ssa = binarize_ssa(grad_ssa)
+
+    # Attach tangent pass. This produces tangent assignments for every SSA
+    # variable, including the `g_syms`. The tangent of `g_syms[j]` under
+    # input direction `eᵢ` is `H[i, j]`.
+    tang_ssa = tangent_code(grad_ssa, vars)
+    grad_tangent_syms = [dotted(g) for g in g_syms]
+
+    code                = Expr(:block, toexpr.(tang_ssa.code)...)
+    input_vars          = toexpr(Symbolics.MakeTuple(vars))
+    input_tangent_vars  = toexpr(Symbolics.MakeTuple(tang_ssa.variables.input_tangents))
+    value_sym           = toexpr(tang_ssa.output)
+    grad_tuple          = toexpr(Symbolics.MakeTuple(g_syms))
+    grad_tangent_tuple  = toexpr(Symbolics.MakeTuple(grad_tangent_syms))
+
+    inner = @RuntimeGeneratedFunction(:(
+        (__inputs, __tangents) -> begin
+            $input_vars         = __inputs
+            $input_tangent_vars = __tangents
+            $code
+            return ($value_sym, $grad_tuple, $grad_tangent_tuple)
+        end
+    ))
+
+    return function hessian_closure(__inputs)
+        T = typeof(first(__inputs))
+        one_T  = one(T)
+        zero_T = zero(T)
+
+        H  = Matrix{T}(undef, n, n)
+        local value
+        local grad
+
+        for i in 1:n
+            dir = ntuple(k -> k == i ? one_T : zero_T, n)
+            v, g, gt = inner(__inputs, dir)
+            if i == 1
+                value = v
+                grad  = g
+            end
+            for j in 1:n
+                H[i, j] = gt[j]
+            end
+        end
+
+        return (value, grad, H)
+    end
+end
+
+hessian(f, vars) = hessian(f(vars), vars)

--- a/test/hessian.jl
+++ b/test/hessian.jl
@@ -1,0 +1,75 @@
+@testset "hessian" begin
+
+    vars = @variables x y z
+
+    @testset "quadratic: x² + y²" begin
+        # ∇f = (2x, 2y), Hessian = [[2, 0], [0, 2]]
+        H = hessian(x^2 + y^2, [x, y])
+        val, grad, M = H((3.0, 4.0))
+        @test val == 25.0
+        @test grad == (6.0, 8.0)
+        @test M == [2.0 0.0; 0.0 2.0]
+    end
+
+    @testset "cross term: x * y" begin
+        # ∇f = (y, x), Hessian = [[0, 1], [1, 0]]
+        H = hessian(x * y, [x, y])
+        _, _, M = H((2.0, 3.0))
+        @test M == [0.0 1.0; 1.0 0.0]
+    end
+
+    @testset "polynomial: x²y + y³" begin
+        # ∇f = (2xy, x² + 3y²)
+        # Hessian:
+        #   ∂²f/∂x² = 2y
+        #   ∂²f/∂x∂y = 2x
+        #   ∂²f/∂y² = 6y
+        H = hessian(x^2 * y + y^3, [x, y])
+        val, grad, M = H((2.0, 3.0))
+        @test val ≈ 2.0^2 * 3.0 + 3.0^3
+        @test grad[1] ≈ 2 * 2.0 * 3.0
+        @test grad[2] ≈ 2.0^2 + 3 * 3.0^2
+        @test M[1, 1] ≈ 2 * 3.0
+        @test M[1, 2] ≈ 2 * 2.0
+        @test M[2, 1] ≈ 2 * 2.0
+        @test M[2, 2] ≈ 6 * 3.0
+    end
+
+    @testset "transcendental: sin(xy)" begin
+        # ∇f = (y cos(xy), x cos(xy))
+        # Hessian:
+        #   ∂²/∂x² = -y² sin(xy)
+        #   ∂²/∂x∂y = cos(xy) - xy sin(xy)
+        #   ∂²/∂y² = -x² sin(xy)
+        H = hessian(sin(x * y), [x, y])
+        xv, yv = 1.0, 2.0
+        _, _, M = H((xv, yv))
+        xy = xv * yv
+        @test M[1, 1] ≈ -yv^2 * sin(xy)
+        @test M[1, 2] ≈ cos(xy) - xy * sin(xy)
+        @test M[2, 1] ≈ cos(xy) - xy * sin(xy)
+        @test M[2, 2] ≈ -xv^2 * sin(xy)
+    end
+
+    @testset "three variables: x² + y² + z² + xyz" begin
+        H = hessian(x^2 + y^2 + z^2 + x*y*z, [x, y, z])
+        _, _, M = H((1.0, 2.0, 3.0))
+        # ∂²/∂x² = 2,  ∂²/∂y² = 2,  ∂²/∂z² = 2
+        # ∂²/∂x∂y = z = 3,  ∂²/∂x∂z = y = 2,  ∂²/∂y∂z = x = 1
+        @test M[1, 1] ≈ 2.0
+        @test M[2, 2] ≈ 2.0
+        @test M[3, 3] ≈ 2.0
+        @test M[1, 2] ≈ 3.0; @test M[2, 1] ≈ 3.0
+        @test M[1, 3] ≈ 2.0; @test M[3, 1] ≈ 2.0
+        @test M[2, 3] ≈ 1.0; @test M[3, 2] ≈ 1.0
+    end
+
+    @testset "symmetry (Schwarz)" begin
+        # ∂²f/∂x∂y = ∂²f/∂y∂x whenever f is C²
+        for ex in (x^3 + 2*x^2*y + y^2, exp(x*y) + x^2*y, sin(x)*cos(y))
+            H = hessian(ex, [x, y])
+            _, _, M = H((0.7, -0.3))
+            @test M[1, 2] ≈ M[2, 1]
+        end
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,6 +8,7 @@ using Test
     include("icp.jl")
     include("hardening.jl")
     include("tangent.jl")
+    include("hessian.jl")
 
 end
 


### PR DESCRIPTION
## Summary

Stacked on #84 (forward-mode AD), which is stacked on #83 (derivative hardening). Adds `hessian(ex, vars)` as the third AD entry point, reusing the same scalar rule table (`unary_rule` / `binary_rule`) as `gradient` and `tangent`.

## How it works

Forward-over-reverse:

1. `gradient_code(ex, vars)` — one reverse-mode pass. Yields an SSA whose `variables.gradient = [g₁, …, gₙ]` are symbolic handles into the code.
2. `binarize_ssa` — decompose any n-ary muls the adjoint left behind (e.g. `2 * _b̄ * x`) so the tangent pass can consume them.
3. `tangent_code` — attach a forward-mode tangent pass on top. Produces tangent assignments for every SSA variable, including the `gᵢ`s.
4. Compiled `(inputs, direction) → (value, gradient, gradient_tangent)`. Invoking it with direction `eᵢ` gives row `i` of the Hessian. The user-facing `hessian` closure loops over `i = 1..n` and assembles the `n × n` matrix.

## API

```julia
@variables x y z
H = hessian(x^2 * y + y^3 + z^3, [x, y, z])
val, grad, M = H((2.0, 3.0, 1.0))
# val :: Float64
# grad :: Tuple{Float64, Float64, Float64}
# M :: Matrix{Float64}  (3×3, Schwarz-symmetric for C² inputs)
```

## Also in this PR

`tangent_eq` is hardened to accept non-call rhs's. Reverse-mode SSA contains `_c̄ := 1` (constant seed) and identity copies like `_b̄ := _c̄`; the previous `tangent_eq` assumed every rhs was a function call and errored the moment gradient SSA was used as forward-mode input. Tangent of a bare constant is 0, tangent of a bare variable is the variable's own tangent — both fall out of `dotted` dispatching on `Real` vs `BasicSymbolic`.

## Test plan

- [x] 95/95 tests pass locally (68 inherited, +27 new for Hessian).
- [x] Closed-form check against `x² + y²` (diagonal `[2, 2]`).
- [x] Cross-term `x·y` (off-diagonal 1s).
- [x] `x²y + y³`, `sin(xy)` — matches hand-derived Hessian.
- [x] 3-variable case `x² + y² + z² + xyz` — dense 3×3.
- [x] Schwarz symmetry check on three non-trivial expressions.

Bump to v0.8.0.

## Performance note

The runtime cost is `n` tangent-pass invocations per `hessian(…)(inputs)` call. Fine for the small-`n` symbolic regime the package targets; denser cases can compile all `n` tangent passes into a single SSA later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)